### PR TITLE
FEAT: adds file validation for size and type

### DIFF
--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -1,4 +1,5 @@
 import { HttpError } from 'http-errors';
+import multer from 'multer';
 
 export const errorHandler = (err, req, res, next) => {
   // Перевірка, чи отримали ми помилку від createHttpError
@@ -9,6 +10,13 @@ export const errorHandler = (err, req, res, next) => {
       data: err,
     });
     return;
+  } else if (err instanceof multer.MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({
+        status: 400,
+        message: 'File size exceeds the 3MB limit',
+      });
+    }
   }
 
   res.status(500).json({

--- a/src/middlewares/multer.js
+++ b/src/middlewares/multer.js
@@ -1,4 +1,5 @@
 import multer from 'multer';
+import createHttpError from 'http-errors';
 
 import { TEMP_UPLOAD_DIR } from '../constants/index.js';
 
@@ -12,4 +13,20 @@ const storage = multer.diskStorage({
   },
 });
 
-export const upload = multer({ storage });
+const limits = { fileSize: 1024 * 1024 * 3 };
+
+export const upload = multer({
+  storage,
+  limits,
+  fileFilter: (req, file, cb) => {
+    if (!file.mimetype.startsWith('image/')) {
+      return cb(
+        createHttpError(
+          400,
+          'Invalid avatar file type. Only images are allowed',
+        ),
+      );
+    }
+    cb(null, true);
+  },
+});


### PR DESCRIPTION
This PR adds file validation for size and type on /user/avatar route (patch). The user's avatar limited by 3 MB. 

These messages will appear if size or type of file isn't correct:

`{
    "status": 400,
    "message": "File size exceeds the 3MB limit"
}` 

`{
    "status": 400,
    "message": "BadRequestError",
    "data": {
        "message": "Invalid avatar file type. Only images are allowed",
        "storageErrors": []
    }
}`